### PR TITLE
[Issue-156] Show the enter PIN code screen when user performs import account by JSON file, accept the camera permission on the Android device

### DIFF
--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,5 +1,6 @@
 import { PERMISSIONS, request, RESULTS } from 'react-native-permissions';
 import { Alert, Linking, Platform } from 'react-native';
+import { AutoLockState } from 'utils/autoLock';
 import i18n from 'utils/i18n/i18n';
 
 export function isTooShortPassword(value: string | null, minLength: number): boolean {
@@ -12,7 +13,9 @@ const getCameraPermission = () => {
 };
 
 export const requestCameraPermission = async () => {
+  AutoLockState.isPreventAutoLock = true;
   const result = await request(getCameraPermission());
+  AutoLockState.isPreventAutoLock = false;
 
   switch (result) {
     case RESULTS.UNAVAILABLE:


### PR DESCRIPTION
### Related issue(s)

- #156

### Is your feature request related to a problem(s)? Please describe.

- Handle case required camera permisson

### Describe the solution you'd like

- Handle case required camera permisson

### Describe alternatives you've considered

- No

### Additional context

- No