### PR TITLE
[Issue-204] Do not show the "Select Validator" field on the unstake screen with the Calamari network

### DIFF
--- a/src/constants/stakingScreen.ts
+++ b/src/constants/stakingScreen.ts
@@ -1,5 +1,26 @@
 export const CHAIN_TYPE_MAP = {
-  relay: ['polkadot', 'kusama', 'aleph', 'alephTest', 'westend', 'polkadex', 'polkadexTest'],
-  para: ['moonbeam', 'moonbase', 'moonriver', 'turing', 'turingStaging', 'bifrost', 'bifrost_testnet'],
+  relay: [
+    'polkadot',
+    'kusama',
+    'aleph',
+    'alephTest',
+    'westend',
+    'polkadex',
+    'polkadexTest',
+    'ternoa',
+    'ternoa',
+    'ternoa_alphanet',
+  ],
+  para: [
+    'moonbeam',
+    'moonbase',
+    'moonriver',
+    'turing',
+    'turingStaging',
+    'bifrost',
+    'bifrost_testnet',
+    'calamari',
+    'calamari_test',
+  ],
   astar: ['astar', 'shiden', 'shibuya'],
 };


### PR DESCRIPTION
### Related issue(s)

- #204

### Is your feature request related to a problem(s)? Please describe.

- Add Calamari Network

### Describe the solution you'd like

- Add Calamari Network

### Describe alternatives you've considered

- No

### Additional context

- No